### PR TITLE
Fix initialization settings

### DIFF
--- a/lib/notification_helper.dart
+++ b/lib/notification_helper.dart
@@ -23,9 +23,9 @@ class NotifHelper {
         AndroidFlutterLocalNotificationsPlugin>();
     await android?.createNotificationChannel(_channel);
 
-    const initSettings = InitializationSettings(
-      android: AndroidInitializationSettings('@mipmap/ic_launcher'),
-      iOS: DarwinInitializationSettings(
+    final initSettings = InitializationSettings(
+      android: const AndroidInitializationSettings('@mipmap/ic_launcher'),
+      iOS: const DarwinInitializationSettings(
         requestAlertPermission: true,
         requestBadgePermission: true,
         requestSoundPermission: true,


### PR DESCRIPTION
## Summary
- remove `const` to avoid compile error with `DarwinNotificationAction.plain`

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845aece118c832384b1dc369a38599e