### PR TITLE
Fix notification helper

### DIFF
--- a/lib/notification_helper.dart
+++ b/lib/notification_helper.dart
@@ -98,8 +98,6 @@ class NotifHelper {
         ),
         payload: payload,
         androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
-        uiLocalNotificationDateInterpretation:
-            UILocalNotificationDateInterpretation.absoluteTime,
         matchDateTimeComponents: DateTimeComponents.time,
       );
 


### PR DESCRIPTION
## Summary
- remove deprecated `UILocalNotificationDateInterpretation` parameter

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b14ebc388323bf6184686a0c0537